### PR TITLE
Allow overriding bucket/table name scheme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .terraform
+.idea
 id_rsa

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+Adds table_name, and bucket_name variables to the hash range store to allow the sepcified names to override the existing naming scheme.

--- a/hash-range-store/locals.tf
+++ b/hash-range-store/locals.tf
@@ -1,0 +1,4 @@
+locals {
+  table_name = var.table_name == "" ? "${var.table_name_prefix}${var.name}" : var.table_name
+  bucket_name = var.bucket_name == "" ? "${var.bucket_name_prefix}${lower(var.name)}" : var.bucket_name
+}

--- a/hash-range-store/variables.tf
+++ b/hash-range-store/variables.tf
@@ -18,3 +18,15 @@ variable "table_name_prefix" {
 variable "tags" {
   type = map(string)
 }
+
+variable "table_name" {
+  description = "Overrides default naming scheme to use specified table name"
+  type = string
+  default = ""
+}
+
+variable "bucket_name" {
+  description = "Overrides default naming scheme to use specified bucket name"
+  type = string
+  default = ""
+}


### PR DESCRIPTION
Allows flexibility in the naming scheme of tables & buckets for a VHS if required.