### PR TITLE
Add the Name tag to VHS DynamoDB tables

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Add the `Name` tag to DynamoDB tables created by this module.

--- a/hash-range-store/dynamo.tf
+++ b/hash-range-store/dynamo.tf
@@ -17,5 +17,10 @@ resource "aws_dynamodb_table" "table" {
     type = "N"
   }
 
-  tags = var.tags
+  tags = merge(
+    var.tags,
+    {
+      Name = local.table_name
+    }
+  )
 }

--- a/hash-store/dynamo.tf
+++ b/hash-store/dynamo.tf
@@ -1,5 +1,9 @@
+locals {
+  table_name = "${var.table_name_prefix}${var.name}"
+}
+
 resource "aws_dynamodb_table" "table" {
-  name             = "${var.table_name_prefix}${var.name}"
+  name             = local.table_name
   hash_key         = "id"
   stream_enabled   = true
   stream_view_type = "NEW_AND_OLD_IMAGES"
@@ -11,5 +15,10 @@ resource "aws_dynamodb_table" "table" {
     type = "S"
   }
 
-  tags = var.tags
+  tags = merge(
+    var.tags,
+    {
+      Name = local.table_name
+    }
+  )
 }


### PR DESCRIPTION
We have the Name tag set up for doing cost allocation, so adding the Name tag to our pipeline tables will allow us to see where we're spending all the money.

For https://github.com/wellcomecollection/platform/issues/4975