### PR TITLE
Don't use an image from Docker Hub in CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM 760097843905.dkr.ecr.eu-west-1.amazonaws.com/python:3.7
 
 ARG COMMAND
 VOLUME /workdir


### PR DESCRIPTION
We've hit rate limits when pulling from Docker Hub in CI, so use an image from ECR to avoid this.